### PR TITLE
use "utf-8" encoding to fix TTS inference

### DIFF
--- a/tts_lightning_modules.py
+++ b/tts_lightning_modules.py
@@ -108,7 +108,7 @@ class TTSModel(LightningModule):
             prepend_space_to_text=prepend_space_to_text,
             append_space_to_text=append_space_to_text,
             add_bos_eos_to_text=add_bos_eos_to_text,
-            phonemizer_cfg=phonemizer_cfg)
+            phonemizer_cfg=phonemizer_cfg, encoding="utf-8")
 
         self.predict_mode = predict_mode
         assert(predict_mode in {'tts', 'reconstruction'})


### PR DESCRIPTION
This enables inference from `model_inputs/resynthesis_prompts.json` to be non-phonemized text.
example
```
    {
      "script": "While complexity makes you sound smart, focusing on the key basics matters more.",
      "spk_id": "ljs",
      "decoder_spk_id": "ljs",
      "duration_spk_id": "ljs",
      "energy_spk_id": "ljs",
      "f0_spk_id": "ljs",
      "language": "en_US",
      "emotion": "other"
    }
```